### PR TITLE
Fix the YouTube link

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,4 +1,4 @@
-The source code to accompany the [[https://www.youtube.com/watch?v%3DvQO7F2Q9DwA][youtube video]] of Magit in Emacs.
+The source code to accompany the [[https://www.youtube.com/watch?v=vQO7F2Q9DwA][youtube video]] of Magit in Emacs.
 This uses the [[https://github.com/howardabrams/demo-it][demo-it]] package for Emacs.
 
 However, I would assume that most people would just want to run the


### PR DESCRIPTION
The link of the YouTube video was wrong. The '=' should be url encoded by accident.

